### PR TITLE
Remove emacs version from package requires

### DIFF
--- a/ivy-yasnippet.el
+++ b/ivy-yasnippet.el
@@ -3,7 +3,7 @@
 ;;
 ;; Author: Michał Kondraciuk <k.michal@zoho.com>
 ;; URL: https://github.com/mkcms/ivy-yasnippet
-;; Package-Requires: ((emacs "25.3") (ivy "0.10.0") (yasnippet "0.12.2") (dash "2.14.1"))
+;; Package-Requires: ((ivy "0.10.0") (yasnippet "0.12.2") (dash "2.14.1"))
 ;; Version: 0.0.1
 ;; Keywords: convenience
 


### PR DESCRIPTION
As I understand it, the emacs package manager does not have an option to set a minimum version for emacs. When I try to install ivy-yasnippet from ELPA, I get `Package emacs not found` errors.

This PR should fix that.