### PR TITLE
fix package-lint/byte-compiler/check-doc warnings/errors

### DIFF
--- a/ivy-yasnippet.el
+++ b/ivy-yasnippet.el
@@ -1,9 +1,8 @@
 ;;; ivy-yasnippet.el --- Preview yasnippets with ivy
 
-;;
 ;; Author: Michał Krzywkowski <k.michal@zoho.com>
 ;; URL: https://github.com/mkcms/ivy-yasnippet
-;; Package-Requires: ((emacs "24") (ivy "0.10.0") (yasnippet "0.12.2") (dash "2.14.1") (cl-lib))
+;; Package-Requires: ((emacs "24.1") (cl-lib "0.6") (ivy "0.10.0") (yasnippet "0.12.2") (dash "2.14.1"))
 ;; Version: 0.0.1
 ;; Keywords: convenience
 
@@ -23,14 +22,13 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+
 ;; This package allows you to select yasnippet snippets using ivy completion.
 ;; When current selection changes in the minibuffer, the snippet contents
 ;; are temporarily expanded in the buffer.
-;;
+
 ;; To use it, call M-x ivy-yasnippet (but make sure you have enabled
 ;; `yas-minor-mode' first).
-;;
 
 ;;; Code:
 
@@ -175,7 +173,7 @@ candidate will be initially selected, unless variable
   (interactive)
   (barf-if-buffer-read-only)
   (unless yas-minor-mode
-    (error "yas-minor-mode not enabled in current buffer"))
+    (error "`yas-minor-mode' not enabled in current buffer"))
   (let* ((ivy-yasnippet--buffer (current-buffer))
 
 	 (ivy-yasnippet--region


### PR DESCRIPTION
### before
```
 ivy-yasn…     6   1 error           Expected (package-name "version-num"), but found (cl-lib). (emacs-lisp-package)
 ivy-yasn…    40  11 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-lib'. (emacs-lisp-package)
 ivy-yas…    98     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   101     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   112     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   124   8 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-decf'. (emacs-lisp-package)
 ivy-yas…   125   8 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-decf'. (emacs-lisp-package)
 ivy-yas…   135     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   151     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   154   8 error           You should depend on (emacs "24.1") if you need `condition-case-unless-debug'. (emacs-lisp-package)
 ivy-yas…   159     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   178     info            Messages should start with a capital letter (emacs-lisp-checkdoc)
 ivy-yas…   192  44 error           You should depend on (emacs "24.3") or the cl-lib package if you need `cl-caddr'. (emacs-lisp-package)
 ivy-yas…   250     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   262   2 warning         ‘ivy-set-display-transformer’ is an obsolete function (as of <2020-05-20 Wed>); Use ‘ivy-configure’ :display-transformer-fn (emacs-lisp)
```

### after
```
 ivy-yasn…    96     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…    99     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   110     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   133     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   149     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   157     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   248     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 ivy-yas…   260   2 warning         ‘ivy-set-display-transformer’ is an obsolete function (as of <2020-05-20 Wed>); Use ‘ivy-configure’ :display-transformer-fn (emacs-lisp)
```